### PR TITLE
Fix the wrong 90% label on progress complete

### DIFF
--- a/src/jquery.progressBarTimer.js
+++ b/src/jquery.progressBarTimer.js
@@ -129,7 +129,7 @@
             if(this._getSecondsFromTicks(this.remainingTicks)<=this.settings.warningThreshold && !bar.hasClass(this.settings.warningStyle)) {                
                 bar.removeClass(this.settings.baseStyle).addClass(this.settings.warningStyle);
             }
-            if (this.remainingTicks === 0) {
+            if (this.remainingTicks < 0) {
                 this.stop();
 
                 bar.removeClass(this.settings.baseStyle)


### PR DESCRIPTION
Because of the operator on line 132, if you use the following option
```
label: {
show: true,
type: 'percent' // or 'seconds' => 23/60
}
``` 
the wrong number appears on the bar when the timer expires. If we use the last tick (tick no. 0) then the last label is 100% not 90%.